### PR TITLE
Handle optional GitHub token provided via '-token' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,21 @@ Pullpigo is a command-line that displays Pull Request statistics for GitHub repo
 
 ## Run
 
+Either:
+
+    go run pullpigo.go -repo=nicokosi/pullpigo
+
+Or if `go build` has already been called:
+
     ./pullpigo -repo=nicokosi/pullpigo
+
+If an [access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) is required:
+
+    ./pullpigo -repo=nicokosi/pullpigo -token=$GITHUB_ACCESS_TOKEN
+
+Display the "usage" (the available command options):
+
+    ./pullpigo --help
 
 ## Code
 

--- a/pullpigo.go
+++ b/pullpigo.go
@@ -10,11 +10,12 @@ import (
 )
 
 func main() {
-	repo := parseFlags()
-	fmt.Printf("GitHub repository '%s'", repo)
-	println()
-
-	events := githubEvents(repo)
+	config := parseFlags()
+	fmt.Printf("GitHub repository '%s'", config.repo)
+	if len(config.token) > 0 {
+		println(" (token provided)")
+	}
+	events := githubEvents(config)
 
 	eventsByAuthor := make(map[actor]int)
 	for _, event := range events {
@@ -26,16 +27,21 @@ func main() {
 	}
 }
 
-// Parse command line arguments to retrieve repository name
-func parseFlags() string {
+type config struct {
+	repo, token string
+}
+
+// Parse command line arguments to retrieve the configuration
+func parseFlags() config {
 	repo := flag.String("repo", "", "a GitHub repository (i.e. 'nicokosi/pullpigo')")
+	token := flag.String("token", "", "an optional GitHub token")
 	flag.Parse()
-	return *repo
+	return config{*repo, *token}
 }
 
 // Retrieve events from GitHub API
-func githubEvents(repo string) []rawEvent {
-	url := fmt.Sprintf("https://api.github.com/repos/%v/events?access_token=&page=1", repo)
+func githubEvents(config config) []rawEvent {
+	url := fmt.Sprintf("https://api.github.com/repos/%v/events?access_token=%v&page=1", config.repo, config.token)
 	resp, getErr := http.Get(url)
 	if getErr != nil {
 		panic(getErr)


### PR DESCRIPTION
Usage example:

	$ go run . -repo=softwarevidal/cinqb -token=$GITHUB_TOKEN

	GitHub repository 'softwarevidal/cinqb' (token provided)
	  5 events created by nicokosi
	  1 events created by jcgay
	  2 events created by dependabot-preview[bot]
	  1 events created by AdrienTurmo
	  19 events created by Jin66
	  2 events created by s-petit