### PR TITLE
Enhance Continuous Integration: lint/check the source code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-go@v1 
-      with:
-        go-version: '1.13.4'
-    - run: go test
-    - run: go build pullpigo.go
+      - uses: actions/checkout@v1
+      - uses: actions/setup-go@v1
+        with:
+          go-version: "1.13.4"
+      - name: Test
+        run: go test
+      - name: Check
+        run: go vet
+      - name: Build
+        run: go build pullpigo.go


### PR DESCRIPTION
[`go vet`](https://golang.org/cmd/vet/) may be a good start.
There are fancy linters like https://golangci.com/product#linters but I am not sure it's worth the time (it adds ~30 s latency in CI) / complexity.