### PR TITLE
Run CI with Go 1.21 🆙

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: "1.20"
+          go-version: "1.21"
       - name: Test
         run: go test -v -cover
       - name: Check


### PR DESCRIPTION
Release note: https://go.dev/doc/go1.21.