### PR TITLE
Stop Dependabot in favor of Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: friday
-    time: "20:00"
-  open-pull-requests-limit: 2


### PR DESCRIPTION
It will prevent from creating duplicated library upgrade pull requests, like:
https://github.com/nicokosi/pullpigo/pull/55 (Renovate)
https://github.com/nicokosi/pullpigo/pull/56 (Dependabot)
