### PR TITLE
Use Go 1.26 via toolchain

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/nicokosi/pullpigo
 
-go 1.25
+go 1.26
+
+toolchain go1.26.0
 
 require github.com/stretchr/testify v1.11.1
 


### PR DESCRIPTION
https://go.dev/doc/toolchain
