### PR TITLE
Replace deprecated `ioutil.ReadAll` with `io.ReadAll`

### DIFF
--- a/pullpigo.go
+++ b/pullpigo.go
@@ -5,7 +5,8 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
+
 	"net/http"
 	"os"
 	"time"
@@ -99,7 +100,7 @@ func githubEvents(config config) []rawEvent {
 			panic(getErr)
 		}
 		defer resp.Body.Close()
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Via `go fix`.

https://pkg.go.dev/io/ioutil#ReadAll
